### PR TITLE
Limited inputs of program_root to ONLY controls_repeat_custom and mov…

### DIFF
--- a/src/custom_blocks.js
+++ b/src/custom_blocks.js
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 .setCheck('motor_name')
                 .appendField('Motor Names:');
             this.appendStatementInput('MAIN_PROGRAM')
-                .setCheck(null)
+                .setCheck(['controls_repeat_custom', 'move'])
                 .appendField('Main Program');
             this.setColour(160); // You can set a custom color for your block
             this.setTooltip('Root block for the program');


### PR DESCRIPTION
I just added a check to make sure that the main program can only accept blocks of type 'controls_repeat_custom' or 'move'. This is to avoid users putting unwanted values into the main program.